### PR TITLE
fix ip detection for namecheap

### DIFF
--- a/lib/registered_domains/namecheap.rb
+++ b/lib/registered_domains/namecheap.rb
@@ -11,7 +11,7 @@ module RegisteredDomains
       attr_reader :domains
 
       def initialize(user, api_key, api_user)
-        ip = ::HTTParty.get('https://www.icanhazip.com')
+        ip = ::HTTParty.get('https://ipv4.icanhazip.com')
         ip.success?
         @config = {
           client_ip: ip,


### PR DESCRIPTION
www.icanhazip.com fails with Net::Open timeout

edit to note: i guess this is because the www has been shut down to limit botnet activity that was abusing the endpoint, but it's been a few weeks at this point so :man_shrugging: 